### PR TITLE
Fixes #8 - Fix urls for images in forms.css

### DIFF
--- a/css/forms.css
+++ b/css/forms.css
@@ -26,8 +26,8 @@
   padding: 0.5294117647em 0.6470588235em;
 }
 .form-select {
-  background-image: url(../img/arrow-alt-down.png);
-  background-image: url(../img/svg/arrow-alt-down.svg);
+  background-image: url(https://www.epa.gov/sites/all/themes/epa/img/arrow-alt-down.png);
+  background-image: url(https://www.epa.gov/sites/all/themes/epa/img/svg/arrow-alt-down.svg);
   background-position: right 0.7647058824em center;
   background-repeat: no-repeat;
   background-size: 0.7647058824em;
@@ -81,8 +81,8 @@ input[type='radio']:checked + label:before {
   box-shadow: 0 0 0 1px #0071bc;
 }
 input[type='checkbox']:checked + label:before {
-  background-image: url(../img/correct.png);
-  background-image: url(../img/svg/correct.svg);
+  background-image: url(https://www.epa.gov/sites/all/themes/epa/img/correct.png);
+  background-image: url(https://www.epa.gov/sites/all/themes/epa/img/svg/correct.svg);
   background-position: 50%;
   background-repeat: no-repeat;
 }
@@ -137,7 +137,7 @@ input[type='radio']:disabled + label:before {
   top: 0;
 }
 .govdelivery-legend:before {
-  background: url(../img/govdelivery.png) no-repeat 50% 50%;
+  background: url(https://www.epa.gov/sites/all/themes/epa/img/govdelivery.png) no-repeat 50% 50%;
   content: '';
   display: block;
   height: 1.4117647059em;

--- a/css/tabs.css
+++ b/css/tabs.css
@@ -67,7 +67,7 @@
 .tabs > li:first-child > a {
   border-radius: 3px 3px 0 0;
 }
-.tabs > li:last-child > a,
+.tabs > li:last-child > a {
   border-radius: 0 0 3px 3px;
 }
 


### PR DESCRIPTION
#8: I just replaced the '..' in the relative paths in forms.css with the absolute path that was used in accordions.css.
#10: I fixed a small typo which was breaking the compilation of tabs.css