### PR TITLE
update to ui.R with commented out code for using the wide template

### DIFF
--- a/RShiny/ui.R
+++ b/RShiny/ui.R
@@ -1,5 +1,7 @@
 # ui.R
 fluidPage(
+  # if width of app feels too narrow, uncomment the following line
+  #tags$body(class = "html wide-template"),
   tags$head(tags$link(rel = "stylesheet",
                       type = "text/css", href = "style.css")),
 # Header


### PR DESCRIPTION
As promised. 

This contains the added line to use the wide template.  I included it commented out so that the default is to not use the wide.

